### PR TITLE
Clarify the two SPNs required for ARO clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ To begin with, register the ARO 4 provider in your subscription:
 az provider register -n Microsoft.RedHatOpenShift --wait
 ```
 
-You require an Azure service principal and the ARO 4 Resource Provider service principal in order to use this template. The template expects the "Object ID" of the service principal. Below are the commands necessary to create this service principal and get its object id.
+You will need an Azure service principal in order to use this template. The template expects the "Object ID" of the service principal. Below are the commands necessary to create this service principal and get its object id.
 
 ```
 az ad sp create-for-rbac --name <appName>
 az ad sp list --filter "displayname eq '<appName>'" --query "[?appDisplayName=='<appName>'].{name: appDisplayName, objectId: objectId}"
 ```
 
-And to obtain the ARO 4 RP service principal object id execute the following command.
+The ARM template also needs to grant the ARO 4 Resource Provider service principal permissions in order to provision and manage clusters. To obtain the ARO 4 RP service principal object id execute the following command.
 
 ```
 az ad sp list --filter "displayname eq 'Azure Red Hat OpenShift RP'" --query "[?appDisplayName=='Azure Red Hat OpenShift RP'].{name: appDisplayName, objectId: objectId}"


### PR DESCRIPTION
There has been confusion about needing two SPNs for ARO clusters. Clarify README to differentiate between the client SPN and the ARO RP SPN.